### PR TITLE
Feature/game state

### DIFF
--- a/source/core/src/main/com/csse3200/game/services/GameState.java
+++ b/source/core/src/main/com/csse3200/game/services/GameState.java
@@ -1,7 +1,10 @@
 package com.csse3200.game.services;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /**
  * Represents the current state of the game and facilitates state transitions
@@ -15,20 +18,17 @@ public class GameState {
     // Holds the current state data
     private Map<String, Object> stateData = new HashMap<>();
 
-    // Callback listener for state changes
-    private StateChangeListener stateChangeListener;
+    // Callback listeners for state changes
+    private List<StateChangeListener> stateChangeListeners = new CopyOnWriteArrayList<>();
 
     /**
-     * Initializes a new GameState instance with a state change listener.
-     *
-     * @param stateChangeListener Listener to be informed of state changes.
+     * Initializes a new GameState instance.
      */
-    public GameState(StateChangeListener stateChangeListener) {
-        this.stateChangeListener = stateChangeListener;
+    public GameState() {
     }
 
     /**
-     * Sets the new state data and triggers the state change callback.
+     * Sets the new state data and triggers the state change callbacks.
      *
      * @param newData New state data to be set.
      */
@@ -36,17 +36,46 @@ public class GameState {
         synchronized (lock) {
             stateData = new HashMap<>(newData);
         }
-        stateChangeListener.onStateChange(this); // Inform about state change
+        notifyStateChangeListeners(); // Inform about state change
     }
 
     /**
-     * Retrieves a safe copy of the current state data.
+     * Retrieves a safe, immutable copy of the current state data.
      *
-     * @return A copy of the current state data.
+     * @return An immutable copy of the current state data.
      */
     public Map<String, Object> getStateData() {
         synchronized (lock) {
-            return new HashMap<>(stateData);
+            return Collections.unmodifiableMap(new HashMap<>(stateData));
+        }
+    }
+
+    /**
+     * Registers a state change listener.
+     *
+     * @param listener The listener to be registered.
+     */
+    public void registerStateChangeListener(StateChangeListener listener) {
+        stateChangeListeners.add(listener);
+    }
+
+    /**
+     * Unregisters a state change listener.
+     *
+     * @param listener The listener to be unregistered.
+     */
+    public void unregisterStateChangeListener(StateChangeListener listener) {
+        stateChangeListeners.remove(listener);
+    }
+
+    private void notifyStateChangeListeners() {
+        // No need for synchronization here, using CopyOnWriteArrayList
+        Map<String, Object> stateCopy;
+        synchronized (lock) {
+            stateCopy = new HashMap<>(stateData);
+        }
+        for (StateChangeListener listener : stateChangeListeners) {
+            listener.onStateChange(stateCopy);
         }
     }
 
@@ -59,9 +88,8 @@ public class GameState {
         /**
          * Callback method triggered when the state changes.
          *
-         * @param newState The new state after the change.
+         * @param newStateData The new state data after the change.
          */
-        void onStateChange(GameState newState);
+        void onStateChange(Map<String, Object> newStateData);
     }
 }
-

--- a/source/core/src/main/com/csse3200/game/services/GameState.java
+++ b/source/core/src/main/com/csse3200/game/services/GameState.java
@@ -1,0 +1,67 @@
+package com.csse3200.game.services;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents the current state of the game and facilitates state transitions
+ * while ensuring thread safety.
+ */
+public class GameState {
+
+    // Mutex lock
+    private final Object lock = new Object();
+
+    // Holds the current state data
+    private Map<String, Object> stateData = new HashMap<>();
+
+    // Callback listener for state changes
+    private StateChangeListener stateChangeListener;
+
+    /**
+     * Initializes a new GameState instance with a state change listener.
+     *
+     * @param stateChangeListener Listener to be informed of state changes.
+     */
+    public GameState(StateChangeListener stateChangeListener) {
+        this.stateChangeListener = stateChangeListener;
+    }
+
+    /**
+     * Sets the new state data and triggers the state change callback.
+     *
+     * @param newData New state data to be set.
+     */
+    public void setStateData(Map<String, Object> newData) {
+        synchronized (lock) {
+            stateData = new HashMap<>(newData);
+        }
+        stateChangeListener.onStateChange(this); // Inform about state change
+    }
+
+    /**
+     * Retrieves a safe copy of the current state data.
+     *
+     * @return A copy of the current state data.
+     */
+    public Map<String, Object> getStateData() {
+        synchronized (lock) {
+            return new HashMap<>(stateData);
+        }
+    }
+
+    /**
+     * Callback interface to be implemented by classes interested in
+     * receiving notifications about state changes.
+     */
+    public interface StateChangeListener {
+
+        /**
+         * Callback method triggered when the state changes.
+         *
+         * @param newState The new state after the change.
+         */
+        void onStateChange(GameState newState);
+    }
+}
+

--- a/source/core/src/main/com/csse3200/game/services/ServiceLocator.java
+++ b/source/core/src/main/com/csse3200/game/services/ServiceLocator.java
@@ -83,7 +83,7 @@ public class ServiceLocator {
   }
 
   public static void registerGameStateService(GameState source) {
-    logger.debug("Registering resource service {}", source);
+    logger.debug("Registering game state service {}", source);
     gameStateService = source;
   }
 

--- a/source/core/src/main/com/csse3200/game/services/ServiceLocator.java
+++ b/source/core/src/main/com/csse3200/game/services/ServiceLocator.java
@@ -1,5 +1,6 @@
 package com.csse3200.game.services;
 
+import com.badlogic.gdx.Game;
 import com.csse3200.game.entities.EntityService;
 import com.csse3200.game.input.InputService;
 import com.csse3200.game.physics.PhysicsService;
@@ -23,7 +24,7 @@ public class ServiceLocator {
   private static GameTime timeSource;
   private static InputService inputService;
   private static ResourceService resourceService;
-
+  private static GameState gameStateService;
 
   public static EntityService getEntityService() {
     return entityService;
@@ -48,6 +49,8 @@ public class ServiceLocator {
   public static ResourceService getResourceService() {
     return resourceService;
   }
+
+  public static GameState getGameStateService() { return gameStateService; }
 
   public static void registerEntityService(EntityService service) {
     logger.debug("Registering entity service {}", service);
@@ -79,6 +82,11 @@ public class ServiceLocator {
     resourceService = source;
   }
 
+  public static void registerGameStateService(GameState source) {
+    logger.debug("Registering resource service {}", source);
+    gameStateService = source;
+  }
+
   public static void clear() {
     entityService = null;
     renderService = null;
@@ -86,6 +94,7 @@ public class ServiceLocator {
     timeSource = null;
     inputService = null;
     resourceService = null;
+    gameStateService = null;
   }
 
   private ServiceLocator() {

--- a/source/core/src/main/com/csse3200/game/services/ServiceLocator.java
+++ b/source/core/src/main/com/csse3200/game/services/ServiceLocator.java
@@ -1,6 +1,5 @@
 package com.csse3200.game.services;
 
-import com.badlogic.gdx.Game;
 import com.csse3200.game.entities.EntityService;
 import com.csse3200.game.input.InputService;
 import com.csse3200.game.physics.PhysicsService;

--- a/source/core/src/test/com/csse3200/game/services/GameStateTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateTest.java
@@ -1,0 +1,119 @@
+package com.csse3200.game.services;
+
+import com.csse3200.game.extensions.GameExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests for the {@link GameState} class.
+ */
+@ExtendWith(GameExtension.class)
+public class GameStateTest {
+    private GameState gameState;
+
+    /**
+     * Sets up the test environment by creating a new instance of {@link GameState}.
+     */
+    @BeforeEach
+    public void setUp() {
+        gameState = new GameState();
+    }
+
+    /**
+     * Tests the {@link GameState#setStateData(Map)} method by setting state data and comparing it to the expected data.
+     */
+    @Test
+    public void testSetStateData() {
+        Map<String, Object> newData = new HashMap<>();
+        newData.put("planet", "Mars");
+        gameState.setStateData(newData);
+
+        assertEquals(newData, gameState.getStateData(), "The state data should match the set data.");
+    }
+
+    /**
+     * Tests the notification mechanism for state change listeners when the state data is updated.
+     * Registers a listener, sets new state data, and verifies that the listener is notified and receives the updated data.
+     */
+    @Test
+    public void testStateChangeListenerNotification() {
+        TestStateChangeListener listener = new TestStateChangeListener();
+        gameState.registerStateChangeListener(listener);
+
+        Map<String, Object> newData = new HashMap<>();
+        newData.put("planet", "Mars");
+        gameState.setStateData(newData);
+
+        assertTrue(listener.isNotified(), "The listener should be notified.");
+        assertEquals(newData, listener.getLastState(), "The listener should receive the updated state data.");
+    }
+
+    /**
+     * Tests the behavior of having multiple state change listeners.
+     * Registers two listeners, updates the state data, and verifies that both listeners are notified and receive the updated data.
+     */
+    private static class TestStateChangeListener implements GameState.StateChangeListener {
+        private boolean notified = false;
+        private Map<String, Object> lastState = null;
+
+        @Override
+        public void onStateChange(Map<String, Object> newStateData) {
+            notified = true;
+            lastState = newStateData;
+        }
+
+        public boolean isNotified() {
+            return notified;
+        }
+
+        public Map<String, Object> getLastState() {
+            return lastState;
+        }
+    }
+
+    /**
+     * Tests the behavior of unregistering a state change listener.
+     * Registers a listener, unregisters it, updates the state data, and verifies that the unregistered listener is not notified.
+     */
+    @Test
+    public void testMultipleStateChangeListeners() {
+        TestStateChangeListener listener1 = new TestStateChangeListener();
+        TestStateChangeListener listener2 = new TestStateChangeListener();
+
+        gameState.registerStateChangeListener(listener1);
+        gameState.registerStateChangeListener(listener2);
+
+        Map<String, Object> newData = new HashMap<>();
+        newData.put("lives", 3);
+        gameState.setStateData(newData);
+
+        assertTrue(listener1.isNotified(), "The first listener should be notified.");
+        assertEquals(newData, listener1.getLastState(), "The first listener should receive the updated state data.");
+
+        assertTrue(listener2.isNotified(), "The second listener should be notified.");
+        assertEquals(newData, listener2.getLastState(), "The second listener should receive the updated state data.");
+    }
+
+    /**
+     * A mock implementation of the {@link GameState.StateChangeListener} interface for testing purposes.
+     */
+    @Test
+    public void testUnregisterStateChangeListener() {
+        TestStateChangeListener listener = new TestStateChangeListener();
+        gameState.registerStateChangeListener(listener);
+        gameState.unregisterStateChangeListener(listener);
+
+        Map<String, Object> newData = new HashMap<>();
+        newData.put("planet", "mars");
+        gameState.setStateData(newData);
+
+        assertFalse(listener.isNotified(), "The unregistered listener should not be notified.");
+    }
+
+}

--- a/source/core/src/test/com/csse3200/game/services/ServiceLocatorTest.java
+++ b/source/core/src/test/com/csse3200/game/services/ServiceLocatorTest.java
@@ -19,21 +19,25 @@ class ServiceLocatorTest {
     RenderService renderService = new RenderService();
     PhysicsService physicsService = mock(PhysicsService.class);
     GameTime gameTime = new GameTime();
+    GameState gameState = new GameState();
 
     ServiceLocator.registerEntityService(entityService);
     ServiceLocator.registerRenderService(renderService);
     ServiceLocator.registerPhysicsService(physicsService);
     ServiceLocator.registerTimeSource(gameTime);
+    ServiceLocator.registerGameStateService(gameState);
 
     assertEquals(ServiceLocator.getEntityService(), entityService);
     assertEquals(ServiceLocator.getRenderService(), renderService);
     assertEquals(ServiceLocator.getPhysicsService(), physicsService);
     assertEquals(ServiceLocator.getTimeSource(), gameTime);
+    assertEquals(ServiceLocator.getGameStateService(), gameState);
 
     ServiceLocator.clear();
     assertNull(ServiceLocator.getEntityService());
     assertNull(ServiceLocator.getRenderService());
     assertNull(ServiceLocator.getPhysicsService());
     assertNull(ServiceLocator.getTimeSource());
+    assertNull(ServiceLocator.getGameStateService());
   }
 }


### PR DESCRIPTION
This pull request introduces a thread-safe GameState class to manage game state transitions as per (#5).

## Documentation:
* Created a wiki page explaining the [usage of the GameState service](https://github.com/UQcsse3200/2023-studio-2/wiki/Managing-Game-State)
* Updated the [ServiceLocator wiki page](https://github.com/UQcsse3200/2023-studio-2/wiki/Service-Locator) to include the GameState service

## Changes Made:
* Created a new class in `com.csse3200.game.services` to represent the game's state.
* Thread Safety: Utilized a mutex lock to ensure safe concurrent access to state 
* State Change Listeners: Implemented callbacks for state change notifications using `StateChangeListener` interface.
* GameState Unit Tests: Introduced comprehensive unit tests within `GameStateTest` class to verify the class functionalities.
* Integrated the `GameState` service with the `ServiceLocator` class.
* Updated the unit tests for the `ServiceLocator` class to cover interactions with the `GameState` class.