### PR TITLE
Feature/simplify state management

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/resources/ProductionComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/resources/ProductionComponent.java
@@ -32,11 +32,13 @@ public class ProductionComponent extends Component {
     @Override
     public void update() {
         super.update();
+        GameState gameState = ServiceLocator.getGameStateService();
         while (this.timer.getTimeSince(this.lastTime) >= this.tickRate) {
             this.getEntity().getEvents().trigger("produceResource", this.produces, this.tickSize);
-            Map<String, Object> gameStateData = ServiceLocator.getGameStateService().getStateData();
-            int newAmount = (int) gameStateData.getOrDefault("resource/" + this.produces.toString(), 0.0) + this.tickSize;
-            gameStateData.put("resource/" + this.produces.toString(), newAmount);
+            String resourceKey = "resource/" + this.produces.toString();
+            int currentAmount = gameState.get(resourceKey) == null ? 0 : (int) gameState.get(resourceKey);
+            int newAmount = currentAmount + this.tickSize;
+            gameState.put(resourceKey, newAmount);
             this.lastTime += this.tickRate;
         }
     }

--- a/source/core/src/test/com/csse3200/game/services/GameStateTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateTest.java
@@ -5,82 +5,37 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-/**
- * Unit tests for the {@link GameState} class.
- */
 @ExtendWith(GameExtension.class)
 public class GameStateTest {
     private GameState gameState;
 
-    /**
-     * Sets up the test environment by creating a new instance of {@link GameState}.
-     */
     @BeforeEach
     public void setUp() {
         gameState = new GameState();
     }
 
-    /**
-     * Tests the {@link GameState#setStateData(Map)} method by setting state data and comparing it to the expected data.
-     */
     @Test
-    public void testSetStateData() {
-        Map<String, Object> newData = new HashMap<>();
-        newData.put("planet", "Mars");
-        gameState.setStateData(newData);
+    public void testPutAndGet() {
+        gameState.put("planet", "Mars");
 
-        assertEquals(newData, gameState.getStateData(), "The state data should match the set data.");
+        assertEquals("Mars", gameState.get("planet"), "The state data should match the set data.");
     }
 
-    /**
-     * Tests the notification mechanism for state change listeners when the state data is updated.
-     * Registers a listener, sets new state data, and verifies that the listener is notified and receives the updated data.
-     */
     @Test
     public void testStateChangeListenerNotification() {
         TestStateChangeListener listener = new TestStateChangeListener();
         gameState.registerStateChangeListener(listener);
 
-        Map<String, Object> newData = new HashMap<>();
-        newData.put("planet", "Mars");
-        gameState.setStateData(newData);
+        gameState.put("planet", "Mars");
 
         assertTrue(listener.isNotified(), "The listener should be notified.");
-        assertEquals(newData, listener.getLastState(), "The listener should receive the updated state data.");
+        assertEquals("Mars", listener.getLastState().get("planet"), "The listener should receive the updated state data.");
     }
 
-    /**
-     * Tests the behavior of having multiple state change listeners.
-     * Registers two listeners, updates the state data, and verifies that both listeners are notified and receive the updated data.
-     */
-    private static class TestStateChangeListener implements GameState.StateChangeListener {
-        private boolean notified = false;
-        private Map<String, Object> lastState = null;
-
-        @Override
-        public void onStateChange(Map<String, Object> newStateData) {
-            notified = true;
-            lastState = newStateData;
-        }
-
-        public boolean isNotified() {
-            return notified;
-        }
-
-        public Map<String, Object> getLastState() {
-            return lastState;
-        }
-    }
-
-    /**
-     * Tests the behavior of unregistering a state change listener.
-     * Registers a listener, unregisters it, updates the state data, and verifies that the unregistered listener is not notified.
-     */
     @Test
     public void testMultipleStateChangeListeners() {
         TestStateChangeListener listener1 = new TestStateChangeListener();
@@ -89,31 +44,42 @@ public class GameStateTest {
         gameState.registerStateChangeListener(listener1);
         gameState.registerStateChangeListener(listener2);
 
-        Map<String, Object> newData = new HashMap<>();
-        newData.put("lives", 3);
-        gameState.setStateData(newData);
+        gameState.put("lives", 3);
 
         assertTrue(listener1.isNotified(), "The first listener should be notified.");
-        assertEquals(newData, listener1.getLastState(), "The first listener should receive the updated state data.");
+        assertEquals(3, listener1.getLastState().get("lives"), "The first listener should receive the updated state data.");
 
         assertTrue(listener2.isNotified(), "The second listener should be notified.");
-        assertEquals(newData, listener2.getLastState(), "The second listener should receive the updated state data.");
+        assertEquals(3, listener2.getLastState().get("lives"), "The second listener should receive the updated state data.");
     }
 
-    /**
-     * A mock implementation of the {@link GameState.StateChangeListener} interface for testing purposes.
-     */
     @Test
     public void testUnregisterStateChangeListener() {
         TestStateChangeListener listener = new TestStateChangeListener();
         gameState.registerStateChangeListener(listener);
         gameState.unregisterStateChangeListener(listener);
 
-        Map<String, Object> newData = new HashMap<>();
-        newData.put("planet", "mars");
-        gameState.setStateData(newData);
+        gameState.put("planet", "mars");
 
         assertFalse(listener.isNotified(), "The unregistered listener should not be notified.");
     }
 
+    private static class TestStateChangeListener implements GameState.StateChangeListener {
+        private boolean notified = false;
+        private ConcurrentHashMap<String, Object> lastState = null;
+
+        @Override
+        public void onStateChange(ConcurrentHashMap<String, Object> newStateData) {
+            notified = true;
+            lastState = newStateData;
+        }
+
+        public boolean isNotified() {
+            return notified;
+        }
+
+        public ConcurrentHashMap<String, Object> getLastState() {
+            return lastState;
+        }
+    }
 }


### PR DESCRIPTION
Ticket: #68 

This pull request refactors the GameState class to provide thread-safe get and put methods to manipulate individual game state entries, following the approach of HashMaps as per (#5).

## Documentation:
* Created a wiki page explaining the [usage of the updated GameState service](https://github.com/UQcsse3200/2023-studio-2/wiki/Managing-Game-State)

## Changes Made:
* Refactored the GameState class by replacing the map cloning methods with direct get and put methods for updating the game state.
* Thread Safety: Utilized `ConcurrentHashMap` to ensure safe concurrent access to state, removing the need for synchronized blocks.
* Updated State Change Listeners: Ensured that listeners receive a consistent view of the state at the point of change, thanks to the atomic operations provided by ConcurrentHashMap.
* Updated GameState Unit Tests: Revised the tests within `GameStateTest` class to verify the functionality of the revised `put` and `get` methods.
* Updated the unit tests for the `ServiceLocator` class to reflect the interactions with the updated GameState class.
* Integrated code using the old GameState API.