### PR TITLE
GameStateObserver + GameStateInteraction JUnit Tests + Javadocs

### DIFF
--- a/source/core/src/main/com/csse3200/game/services/GameStateInteraction.java
+++ b/source/core/src/main/com/csse3200/game/services/GameStateInteraction.java
@@ -2,30 +2,57 @@ package com.csse3200.game.services;
 
 import java.util.Map;
 
+/**
+ * A utility interaction class to manage and modify game state
+ */
 public class GameStateInteraction {
 
-    private GameState gameState = new GameState();
+    // Corresponding GameState to be managed by interactions
+    private final GameState gameState = new GameState();
 
+    /**
+     * Updates or adds the given key-value pair in the game state data.
+     *
+     * @param key   The key to associate the value with.
+     * @param value The corresponding value to save to the key.
+     */
     public void put(String key, Object value) {
         gameState.put(key, value);
     }
 
+    /**
+     * Returns the value stored at the give key in the game state.
+     *
+     * @param key   The key from which the value should be retrieved from.
+     * @return      The value stored at the given key, or null if key found.
+     */
     public Object get(String key) {
         return gameState.get(key);
     }
 
+    /**
+     * Returns a copy of the current entire game state data.
+     *
+     * @return  A map of game state data at the current moment.
+     */
     public Map<String, Object> getStateData() {
         return gameState.getStateData();
     }
 
+    /**
+     * Increases the specified resource name by a given amount.
+     * Retrieves the current amount stored and adds the given amount.
+     * Note: the game state key is "resource/{resourceName}" not just the resource's name.
+     *
+     * @param resourceName  The name of the resource to be saved.
+     * @param changeAmount  The amount the resource should increase by.
+     */
     public void updateResource(String resourceName, int changeAmount){
         String resourceKey = "resource/" + resourceName;
         Object value = gameState.get(resourceKey);
         int amount = value == null ? 0 : (int) value;
         this.put(resourceKey, amount + changeAmount);
     }
-
-
 }
 
 

--- a/source/core/src/main/com/csse3200/game/services/GameStateInteraction.java
+++ b/source/core/src/main/com/csse3200/game/services/GameStateInteraction.java
@@ -8,7 +8,25 @@ import java.util.Map;
 public class GameStateInteraction {
 
     // Corresponding GameState to be managed by interactions
-    private final GameState gameState = new GameState();
+    private final GameState gameState;
+
+    /**
+     * Constructs a GameStateInteraction instance.
+     * Initialises a GameState.
+     */
+    public GameStateInteraction() {
+        this.gameState = new GameState();
+    }
+
+    /**
+     * Constructs a GameStateInteraction instance.
+     * Manages the given GameState.
+     *
+     * @param gameState The chosen GameState to modify and manage.
+     */
+    public GameStateInteraction(GameState gameState) {
+        this.gameState = gameState;
+    }
 
     /**
      * Updates or adds the given key-value pair in the game state data.

--- a/source/core/src/main/com/csse3200/game/services/GameStateObserver.java
+++ b/source/core/src/main/com/csse3200/game/services/GameStateObserver.java
@@ -17,7 +17,18 @@ public class GameStateObserver extends EventHandler {
      * Initialises the GameStateInteraction and registers event listeners.
      */
     public GameStateObserver() {
-        stateInteraction =  new GameStateInteraction();
+        this.stateInteraction =  new GameStateInteraction();
+        this.generateStateListeners();
+    }
+
+    /**
+     * Constructs the GameStateObserver instance.
+     * Uses the given GameStateInteraction for interactions and registers event listeners.
+     *
+     * @param gameStateInteractor   The chosen GameStateInteraction to interface with.
+     */
+    public  GameStateObserver(GameStateInteraction gameStateInteractor) {
+        this.stateInteraction = gameStateInteractor;
         this.generateStateListeners();
     }
 

--- a/source/core/src/main/com/csse3200/game/services/GameStateObserver.java
+++ b/source/core/src/main/com/csse3200/game/services/GameStateObserver.java
@@ -1,32 +1,49 @@
 package com.csse3200.game.services;
 
-
 import com.csse3200.game.events.EventHandler;
-
 import java.util.Map;
 
+/**
+ * The global game state observer class (EventHandler) that allows components
+ * to interface with the stored game state data using event calls and triggers.
+ */
+public class GameStateObserver extends EventHandler {
 
-public class GameStateObserver extends EventHandler{
-
+    // The interaction instance to define corresponding game state and modification.
     private final GameStateInteraction stateInteraction;
 
+    /**
+     * Constructs the GameStateObserver instance.
+     * Initialises the GameStateInteraction and registers event listeners.
+     */
     public GameStateObserver() {
         stateInteraction =  new GameStateInteraction();
         this.generateStateListeners();
     }
 
+    /**
+     * Generates the listeners for specific game state modification events.
+     * Associates the chosen event name to listen for with corresponding state interaction method.
+     */
     private void generateStateListeners() {
         this.addListener("resourceAdd", stateInteraction::updateResource);
     }
 
-    // Testing method to get full state data
+    /**
+     * Returns a copy of the entire game state at the current moment.
+     * @return  A map of the game state data.
+     */
     public Map<String, Object> getFullStateData() {
         return stateInteraction.getStateData();
     }
 
+    /**
+     * Returns the value corresponding to the given key in the game state data.
+     *
+     * @param key   The key for which the value should be retrieved from
+     * @return      The value at the given key, or null if key doesn't exist.
+     */
     public Object getStateData(String key) {
         return stateInteraction.get(key);
     }
-
-
 }

--- a/source/core/src/test/com/csse3200/game/services/GameStateInteractionTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateInteractionTest.java
@@ -1,0 +1,81 @@
+package com.csse3200.game.services;
+
+import com.csse3200.game.extensions.GameExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@ExtendWith(GameExtension.class)
+public class GameStateInteractionTest {
+
+    GameState gameState;
+    GameStateInteraction stateInteraction;
+
+    @BeforeEach
+    public void setUp(){
+        gameState = new GameState();
+        stateInteraction = new GameStateInteraction(gameState);
+    }
+
+    @Test
+    public void testPutData() {
+        String key1 = "testKey1";
+        int value1 = 100;
+        String key2 = "testKey2";
+        String value2 = "testValue";
+
+        stateInteraction.put(key1, value1);
+        stateInteraction.put(key2, value2);
+
+        assertEquals(gameState.get(key1), value1);
+        assertEquals(gameState.get(key2), value2);
+    }
+
+    @Test
+    public void testGetData() {
+        String key1 = "testKey1";
+        int value1 = 100;
+        String key2 = "testKey2";
+        String value2 = "testValue";
+
+        gameState.put(key1, value1);
+        gameState.put(key2, value2);
+
+        assertEquals(stateInteraction.get(key1), value1);
+        assertEquals(stateInteraction.get(key2), value2);
+        assertNull(stateInteraction.get("Not found key"));
+    }
+
+    @Test
+    public void testGetAllStateData() {
+        String key1 = "testKey1";
+        int value1 = 100;
+        String key2 = "testKey2";
+        String value2 = "testValue";
+        gameState.put(key1, value1);
+        gameState.put(key2, value2);
+
+        Map<String, Object> map = new HashMap<>();
+        map.put(key1, value1);
+        map.put(key2, value2);
+
+        assertEquals(stateInteraction.getStateData(), map);
+    }
+
+    @Test
+    public void testUpdateResource() {
+        String resourceName = "testResource1";
+        int startAmount = 1000;
+        int changeAmount = 500;
+
+        stateInteraction.updateResource(resourceName, startAmount);
+        assertEquals(gameState.get("resource/" + resourceName), startAmount);
+
+        stateInteraction.updateResource(resourceName, changeAmount);
+        assertEquals(gameState.get("resource/" + resourceName), startAmount + changeAmount);
+    }
+}

--- a/source/core/src/test/com/csse3200/game/services/GameStateObserverTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateObserverTest.java
@@ -1,0 +1,59 @@
+package com.csse3200.game.services;
+
+import com.csse3200.game.extensions.GameExtension;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+@ExtendWith(GameExtension.class)
+public class GameStateObserverTest {
+
+    GameStateObserver stateObserver;
+    GameStateInteraction stateInteraction;
+
+    @BeforeEach
+    public void setUp() {
+        stateInteraction = new GameStateInteraction();
+        stateObserver = new GameStateObserver(stateInteraction);
+    }
+
+    @Test
+    public void testAddListener() {
+        int setValue = 100;
+
+        AtomicInteger value = new AtomicInteger();
+        stateObserver.addListener("testListener1", (amount) -> value.set((Integer) amount));
+
+        stateObserver.trigger("testListener1", setValue);
+
+        assertEquals(setValue, value.get());
+    }
+
+    @Test
+    public void testTriggerCallback() {
+        String name = "testResource1";
+        int amount = 100;
+
+        stateObserver.trigger("resourceAdd", name, amount);
+
+        assertEquals(stateInteraction.get("resource/" + name), amount);
+    }
+
+    @Test
+    public void testGetStateData() {
+        String key1 = "testKey1";
+        int value1 = 200;
+        String key2 = "testKey2";
+        String value2 = "testValue";
+
+        stateInteraction.put(key1, value1);
+        stateInteraction.put(key2, value2);
+
+        assertEquals(stateObserver.getStateData(key1), value1);
+        assertEquals(stateObserver.getStateData(key2), value2);
+        assertNull(stateObserver.getStateData("Not found key value"));
+    }
+}

--- a/source/core/src/test/com/csse3200/game/services/ServiceLocatorTest.java
+++ b/source/core/src/test/com/csse3200/game/services/ServiceLocatorTest.java
@@ -19,21 +19,25 @@ class ServiceLocatorTest {
     RenderService renderService = new RenderService();
     PhysicsService physicsService = mock(PhysicsService.class);
     GameTime gameTime = new GameTime();
+    GameStateObserver stateObserver = new GameStateObserver();
 
     ServiceLocator.registerEntityService(entityService);
     ServiceLocator.registerRenderService(renderService);
     ServiceLocator.registerPhysicsService(physicsService);
     ServiceLocator.registerTimeSource(gameTime);
+    ServiceLocator.registerGameStateObserverService(stateObserver);
 
     assertEquals(ServiceLocator.getEntityService(), entityService);
     assertEquals(ServiceLocator.getRenderService(), renderService);
     assertEquals(ServiceLocator.getPhysicsService(), physicsService);
     assertEquals(ServiceLocator.getTimeSource(), gameTime);
+    assertEquals(ServiceLocator.getGameStateObserverService(), stateObserver);
 
     ServiceLocator.clear();
     assertNull(ServiceLocator.getEntityService());
     assertNull(ServiceLocator.getRenderService());
     assertNull(ServiceLocator.getPhysicsService());
     assertNull(ServiceLocator.getTimeSource());
+    assertNull(ServiceLocator.getGameStateObserverService());
   }
 }


### PR DESCRIPTION
Ticket: #81.

This pull request adds JUnit testing for the `GameStateObserver` and `GameStateInteraction` classes.
Javadocs for both classes were also added, and additional constructors to allow access to existing Interaction and State methods.

## Changes Made:
- Added test to `ServiceLocatorTest` to ensure the `GameStateObserver` is registered correctly.
- Added `GameStateObserver` tests to ensure working and expected functionality for all methods of interaction.
- Added `GameStateInteraction` tests to ensure working and expected functionality for all methods of interaction.
- Added Javadocs for `GameStateObserver` and `GameStateInteraction` to aid in explaining what each method does.
- Added additional constructors to `GameStateObserver` and `GameStateInteraction` to allow usage of existing Interaction and State instances.