### PR TITLE
Main Fix + Slight Cleanup

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/resources/ProductionComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/resources/ProductionComponent.java
@@ -2,7 +2,6 @@ package com.csse3200.game.components.resources;
 
 import com.csse3200.game.components.CombatStatsComponent;
 import com.csse3200.game.components.Component;
-import com.csse3200.game.services.GameState;
 import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ServiceLocator;
 

--- a/source/core/src/main/com/csse3200/game/entities/factories/StructureFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/StructureFactory.java
@@ -21,12 +21,12 @@ import com.badlogic.gdx.physics.box2d.BodyDef.BodyType;
  * Factory to create structure entities - such as extractors or ships.
  *
  * <p>Each obstacle entity type should have a creation method that returns a corresponding entity.
- * @param health the max and initial health of the extractor
- * @param producedResource the resource type produced by the extractor
- * @param tickRate the frequency at which the extractor ticks (produces resources)
- * @param tickSize the amount of the resource produced at each tick
  */
 public class StructureFactory {
+    // * @param health the max and initial health of the extractor
+    // * @param producedResource the resource type produced by the extractor
+    // * @param tickRate the frequency at which the extractor ticks (produces resources)
+    // * @param tickSize the amount of the resource produced at each tick
     public static Entity createExtractor(int health, Resource producedResource, long tickRate, int tickSize) {
         Entity extractor = new Entity()
                 .addComponent(new DamageTextureComponent("images/elixir_collector.png")

--- a/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainGameScreen.java
@@ -18,7 +18,6 @@ import com.csse3200.game.physics.PhysicsEngine;
 import com.csse3200.game.physics.PhysicsService;
 import com.csse3200.game.rendering.RenderService;
 import com.csse3200.game.rendering.Renderer;
-import com.csse3200.game.services.GameState;
 import com.csse3200.game.services.GameStateObserver;
 import com.csse3200.game.services.GameTime;
 import com.csse3200.game.services.ResourceService;

--- a/source/core/src/main/com/csse3200/game/screens/MainMenuScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/MainMenuScreen.java
@@ -12,7 +12,6 @@ import com.csse3200.game.input.InputDecorator;
 import com.csse3200.game.input.InputService;
 import com.csse3200.game.rendering.RenderService;
 import com.csse3200.game.rendering.Renderer;
-import com.csse3200.game.services.GameState;
 import com.csse3200.game.services.ResourceService;
 import com.csse3200.game.services.ServiceLocator;
 import org.slf4j.Logger;

--- a/source/core/src/main/com/csse3200/game/services/GameState.java
+++ b/source/core/src/main/com/csse3200/game/services/GameState.java
@@ -1,5 +1,6 @@
 package com.csse3200.game.services;
 
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -9,7 +10,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 public class GameState {
 
     // Holds the current state's information.
-    private ConcurrentHashMap<String, Object> stateData = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Object> stateData = new ConcurrentHashMap<>();
 
     // Callback list of state changes' listeners.
     private final CopyOnWriteArrayList<StateChangeListener> stateChangeListeners = new CopyOnWriteArrayList<>();
@@ -40,7 +41,7 @@ public class GameState {
      *
      * @return The copy of current state data
      */
-    public ConcurrentHashMap<String, Object> getStateData() {
+    public Map<String, Object> getStateData() {
         return new ConcurrentHashMap<>(stateData);
     }
 

--- a/source/core/src/test/com/csse3200/game/services/GameStateInteractionTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateInteractionTest.java
@@ -10,19 +10,19 @@ import java.util.HashMap;
 import java.util.Map;
 
 @ExtendWith(GameExtension.class)
-public class GameStateInteractionTest {
+class GameStateInteractionTest {
 
     GameState gameState;
     GameStateInteraction stateInteraction;
 
     @BeforeEach
-    public void setUp(){
+    void setUp(){
         gameState = new GameState();
         stateInteraction = new GameStateInteraction(gameState);
     }
 
     @Test
-    public void testPutData() {
+    void testPutData() {
         String key1 = "testKey1";
         int value1 = 100;
         String key2 = "testKey2";
@@ -36,7 +36,7 @@ public class GameStateInteractionTest {
     }
 
     @Test
-    public void testGetData() {
+    void testGetData() {
         String key1 = "testKey1";
         int value1 = 100;
         String key2 = "testKey2";
@@ -51,7 +51,7 @@ public class GameStateInteractionTest {
     }
 
     @Test
-    public void testGetAllStateData() {
+    void testGetAllStateData() {
         String key1 = "testKey1";
         int value1 = 100;
         String key2 = "testKey2";
@@ -67,7 +67,7 @@ public class GameStateInteractionTest {
     }
 
     @Test
-    public void testUpdateResource() {
+    void testUpdateResource() {
         String resourceName = "testResource1";
         int startAmount = 1000;
         int changeAmount = 500;

--- a/source/core/src/test/com/csse3200/game/services/GameStateObserverTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateObserverTest.java
@@ -9,19 +9,19 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @ExtendWith(GameExtension.class)
-public class GameStateObserverTest {
+class GameStateObserverTest {
 
     GameStateObserver stateObserver;
     GameStateInteraction stateInteraction;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         stateInteraction = new GameStateInteraction();
         stateObserver = new GameStateObserver(stateInteraction);
     }
 
     @Test
-    public void testAddListener() {
+    void testAddListener() {
         int setValue = 100;
 
         AtomicInteger value = new AtomicInteger();
@@ -33,7 +33,7 @@ public class GameStateObserverTest {
     }
 
     @Test
-    public void testTriggerCallback() {
+    void testTriggerCallback() {
         String name = "testResource1";
         int amount = 100;
 
@@ -43,7 +43,7 @@ public class GameStateObserverTest {
     }
 
     @Test
-    public void testGetStateData() {
+    void testGetStateData() {
         String key1 = "testKey1";
         int value1 = 200;
         String key2 = "testKey2";

--- a/source/core/src/test/com/csse3200/game/services/GameStateTest.java
+++ b/source/core/src/test/com/csse3200/game/services/GameStateTest.java
@@ -10,23 +10,23 @@ import java.util.concurrent.ConcurrentHashMap;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ExtendWith(GameExtension.class)
-public class GameStateTest {
+class GameStateTest {
     private GameState gameState;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         gameState = new GameState();
     }
 
     @Test
-    public void testPutAndGet() {
+    void testPutAndGet() {
         gameState.put("planet", "Mars");
 
         assertEquals("Mars", gameState.get("planet"), "The state data should match the set data.");
     }
 
     @Test
-    public void testStateChangeListenerNotification() {
+    void testStateChangeListenerNotification() {
         TestStateChangeListener listener = new TestStateChangeListener();
         gameState.registerStateChangeListener(listener);
 
@@ -37,7 +37,7 @@ public class GameStateTest {
     }
 
     @Test
-    public void testMultipleStateChangeListeners() {
+    void testMultipleStateChangeListeners() {
         TestStateChangeListener listener1 = new TestStateChangeListener();
         TestStateChangeListener listener2 = new TestStateChangeListener();
 
@@ -54,7 +54,7 @@ public class GameStateTest {
     }
 
     @Test
-    public void testUnregisterStateChangeListener() {
+    void testUnregisterStateChangeListener() {
         TestStateChangeListener listener = new TestStateChangeListener();
         gameState.registerStateChangeListener(listener);
         gameState.unregisterStateChangeListener(listener);


### PR DESCRIPTION
This commit fixes main so the building of Javadocs runs successfully. There are also slight code smell cleanups for the `GameState` and their test suites. 

## Changes Made:
- Modifed `StructureFactory` to remove failing Javadoc params.
- Fixed `GameState.getStateData` to return the appropriate interface.
- Cleaned up `GameStateTest`, `GameStateInterfaceTest`, and `GameStateObserver`
- Removed old, redundant imports from files that used old `GameState` interactions.

