### PR TITLE
Fixed multiple bugs causing excessive thread spawning.

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/ProjectileAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/ProjectileAttackComponent.java
@@ -10,9 +10,7 @@ import com.csse3200.game.physics.PhysicsLayer;
 import com.csse3200.game.physics.components.HitboxComponent;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import com.csse3200.game.rendering.AnimationRenderComponent;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import com.badlogic.gdx.utils.Timer;
 
 /**
  * When this entity touches a valid enemy's hitbox, deal damage to them and apply a knockback.
@@ -125,14 +123,14 @@ public class ProjectileAttackComponent extends Component {
     float deathAnimationDuration = animator.getAnimationDuration("explode");
     // Convert the duration from seconds to milliseconds for the Timer
     long delay = (long) (deathAnimationDuration * 1000);
-    Timer timer = new Timer();
 
-    timer.schedule(new TimerTask() {
+    // Delay based on the dispose animation duration
+    Timer.schedule(new Timer.Task(){
       @Override
       public void run() {
         Gdx.app.postRunnable(entity::dispose);
       }
-    }, delay); // Delay based on the dispose animation duration
+    }, delay);
 
   }
 

--- a/source/core/src/main/com/csse3200/game/components/TouchAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/TouchAttackComponent.java
@@ -9,9 +9,7 @@ import com.csse3200.game.physics.PhysicsLayer;
 import com.csse3200.game.physics.components.HitboxComponent;
 import com.csse3200.game.physics.components.PhysicsComponent;
 import com.csse3200.game.ui.DialogComponent;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import com.badlogic.gdx.utils.Timer;
 
 /**
  * TouchAttackComponent is responsible for dealing damage and applying knockback to entities when
@@ -29,7 +27,6 @@ public class TouchAttackComponent extends Component {
   private CombatStatsComponent combatStats;
   private HitboxComponent hitboxComponent;
   private boolean leftContact;
-  private Timer triggerTimer;
 
   /**
    * Creates a TouchAttackComponent that attacks entities on collision, without knockback.
@@ -66,13 +63,7 @@ public class TouchAttackComponent extends Component {
     leftContact = true;
 
   }
-
-  /**
-   * Handles collision start events and applies damage and knockback to the target entity.
-   *
-   * @param me The fixture associated with this entity's hitbox.
-   * @param other The fixture of the colliding entity.
-   */
+  
   /**
    * Initial collision between current entity and target entity.
    * Deals single instance of damage when hit by enemy.
@@ -103,7 +94,22 @@ public class TouchAttackComponent extends Component {
       return;
     }
 
-    hitOnce(target, source, sourceStats, targetStats);
+    // Targeting STRUCTURE entity type
+    if (target.getComponent(HitboxComponent.class).getLayer() == PhysicsLayer.STRUCTURE) {
+      // Schedule the trigger every 2 seconds
+      Timer.Task task = new Timer.Task() {
+        @Override
+        public void run() {
+          if (!leftContact) {
+            hitOnce(target, source, sourceStats, targetStats);
+          }
+        }
+      };
+      Timer.schedule(task, 2000, 2000); // Initial delay: 2000, Repeat every 2000 milliseconds (2 seconds)
+    } else {
+      // hit once, push away
+      hitOnce(target, source, sourceStats, targetStats);
+    }
   }
 
   /**

--- a/source/core/src/main/com/csse3200/game/components/TouchAttackComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/TouchAttackComponent.java
@@ -102,22 +102,8 @@ public class TouchAttackComponent extends Component {
     if (target.getComponent(HitboxComponent.class) == null) {
       return;
     }
-    // Targeting STRUCTURE entity type
-    if (target.getComponent(HitboxComponent.class).getLayer() == PhysicsLayer.STRUCTURE) {
-      triggerTimer = new Timer();
-      // Schedule the trigger every 2 seconds
-      triggerTimer.scheduleAtFixedRate(new TimerTask() {
-        @Override
-        public void run() {
-          if (!leftContact) {
-            hitOnce(target, source, sourceStats, targetStats);
-          }
-        }
-      }, 2000, 2000); // Initial delay: 2000, Repeat every 2000 milliseconds (2 seconds)
-    } else {
-      //hit once, push away
-      hitOnce(target, source, sourceStats, targetStats);
-    }
+
+    hitOnce(target, source, sourceStats, targetStats);
   }
 
   /**
@@ -144,15 +130,6 @@ public class TouchAttackComponent extends Component {
         }
       }
 
-      // Gives a delay every time there is a collision for the
-      // attack animation to complete
-      Timer timer = new Timer();
-      timer.schedule(new TimerTask() {
-        @Override
-        public void run() {
-          targetStats.hit(combatStats);
-        }
-      }, 2000);
       targetStats.hit(combatStats);
 
       // Apply knockback

--- a/source/core/src/main/com/csse3200/game/components/resources/PopupComponent.java
+++ b/source/core/src/main/com/csse3200/game/components/resources/PopupComponent.java
@@ -4,9 +4,7 @@ import com.badlogic.gdx.Gdx;
 import com.csse3200.game.components.Component;
 import com.csse3200.game.rendering.TextureRenderComponent;
 import com.csse3200.game.services.GameTime;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import com.badlogic.gdx.utils.Timer;
 
 public class PopupComponent extends Component {
     GameTime timer;
@@ -42,13 +40,7 @@ public class PopupComponent extends Component {
         lastTime = timer.getTime();
 
         if (lifespan > duration) {
-            Timer timer = new Timer();
-            timer.schedule(new TimerTask() {
-                @Override
-                public void run() {
-                    Gdx.app.postRunnable(entity::dispose);
-                }
-            }, 2);
+            Gdx.app.postRunnable(entity::dispose);
         }
 
 

--- a/source/core/src/main/com/csse3200/game/components/tasks/AdjustedChaseTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/AdjustedChaseTask.java
@@ -9,9 +9,7 @@ import com.csse3200.game.physics.PhysicsLayer;
 import com.csse3200.game.physics.raycast.RaycastHit;
 import com.csse3200.game.rendering.DebugRenderer;
 import com.csse3200.game.services.ServiceLocator;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import com.badlogic.gdx.utils.Timer;
 
 import static java.lang.Math.abs;
 
@@ -60,8 +58,8 @@ public class AdjustedChaseTask extends DefaultTask implements PriorityTask {
     if(direction == '>'||direction == '='){
       this.owner.getEntity().getEvents().trigger("chaseStart");
     }
-    Timer timer = new Timer();
-    timer.schedule(new TimerTask() {
+
+    Timer.schedule(new Timer.Task(){
       @Override
       public void run() {
         if(getDirection(target.getPosition() )!= direction){
@@ -69,6 +67,7 @@ public class AdjustedChaseTask extends DefaultTask implements PriorityTask {
         }
       }
     },500);
+
   }
 
   @Override

--- a/source/core/src/main/com/csse3200/game/components/tasks/BossTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/BossTask.java
@@ -11,8 +11,7 @@ import com.csse3200.game.physics.raycast.RaycastHit;
 import com.csse3200.game.rendering.DebugRenderer;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.components.CombatStatsComponent;
-import java.util.Timer;
-import java.util.TimerTask;
+import com.badlogic.gdx.utils.Timer;
 
 /**
  * BossTask controls actions of the Boss Entity. Responsible for attacking
@@ -73,8 +72,8 @@ public class BossTask extends DefaultTask implements PriorityTask {
     if(direction == '>'||direction == '='){
       this.owner.getEntity().getEvents().trigger("chaseStart");
     }
-    Timer timer = new Timer();
-    timer.schedule(new TimerTask() {
+
+    Timer.schedule(new Timer.Task(){
       @Override
       public void run() {
         if(getDirection(target.getPosition() )!= direction){

--- a/source/core/src/main/com/csse3200/game/components/tasks/ChaseTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/ChaseTask.java
@@ -9,10 +9,8 @@ import com.csse3200.game.physics.PhysicsLayer;
 import com.csse3200.game.physics.raycast.RaycastHit;
 import com.csse3200.game.rendering.DebugRenderer;
 import com.csse3200.game.services.ServiceLocator;
-
+import com.badlogic.gdx.utils.Timer;
 import java.util.ArrayList;
-import java.util.Timer;
-import java.util.TimerTask;
 
 /** Chases a target entity until they get too far away or line of sight is lost */
 public class ChaseTask extends DefaultTask implements PriorityTask {
@@ -74,8 +72,8 @@ public class ChaseTask extends DefaultTask implements PriorityTask {
     if(direction == '>'||direction == '='){
       this.owner.getEntity().getEvents().trigger("chaseStart");
     }
-    Timer timer = new Timer();
-    timer.schedule(new TimerTask() {
+
+    Timer.schedule(new Timer.Task(){
       @Override
       public void run() {
         if(getDirection(target.getPosition() )!= direction){

--- a/source/core/src/main/com/csse3200/game/components/tasks/RunTask.java
+++ b/source/core/src/main/com/csse3200/game/components/tasks/RunTask.java
@@ -11,9 +11,7 @@ import com.csse3200.game.physics.raycast.RaycastHit;
 import com.csse3200.game.rendering.DebugRenderer;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.utils.math.Vector2Utils;
-
-import java.util.Timer;
-import java.util.TimerTask;
+import com.badlogic.gdx.utils.Timer;
 
 /** Runs away from target entity if it gets too close */
 public class RunTask extends DefaultTask implements PriorityTask {
@@ -51,8 +49,7 @@ public class RunTask extends DefaultTask implements PriorityTask {
     if(direction == '>'||direction == '='){
       this.owner.getEntity().getEvents().trigger("chaseStart");
     }
-    Timer timer = new Timer();
-    timer.schedule(new TimerTask() {
+    Timer.schedule(new Timer.Task(){
       @Override
       public void run() {
         if(getDirection(target.getPosition() )!= direction){


### PR DESCRIPTION
# The issue
* The `java.util.Timer` was being used multiple times throughout the codebase, causing over a hundred thousand threads to be spawned in normal gameplay
* This caused a numerous performance issues and even the occasional `OutOfMemory` exceptions.
* Additonally, LibGDX is not generally thread-safe except for specific classes, thus this behaviour was unsafe.

# Solution
* Removing unnecessary timers
* Switching over the necessary timers to use LibGDX's implementation of timers, which run in the main game thread instead of a new thread.

# Other info
Attached below is a screenshot of the profiler when running the unpatched game. Note that there are a total of 43k threads started.
<img width="767" alt="Level 2" src="https://github.com/UQcsse3200/2023-studio-2/assets/27803813/985df482-a0c2-46cc-8ae4-1a4b087245a6">
