### PR TITLE
Fix: EntityService Game Crash + other file path bugs

### DIFF
--- a/source/core/src/main/com/csse3200/game/components/PowerUpDisplayHUD.java
+++ b/source/core/src/main/com/csse3200/game/components/PowerUpDisplayHUD.java
@@ -6,6 +6,9 @@ import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.scenes.scene2d.ui.Image;
 import com.badlogic.gdx.scenes.scene2d.ui.Label;
 import com.badlogic.gdx.scenes.scene2d.ui.Table;
+import com.csse3200.game.entities.configs.PowerupConfig;
+import com.csse3200.game.entities.configs.PowerupConfigs;
+import com.csse3200.game.files.FileLoader;
 import com.csse3200.game.services.ServiceLocator;
 import com.csse3200.game.ui.UIComponent;
 
@@ -18,7 +21,7 @@ public class PowerUpDisplayHUD extends UIComponent {
 
     public PowerupType powerUpEntity;
     private Label PowerUpLabel;
-
+    private final PowerupConfigs configs = FileLoader.readClass(PowerupConfigs .class, "configs/powerups.json");
     Image SpeedUpImage = null;
     Image HealthUpImage = null;
     Image ExtraLifeImage = null;
@@ -39,22 +42,8 @@ public class PowerUpDisplayHUD extends UIComponent {
      */
     //
     public Image selectPowerUp() {
-
-        if (powerUpEntity == PowerupType.HEALTH_BOOST) {
-            HealthUpImage = new Image(ServiceLocator.getResourceService().getAsset("images/Potion2re.png", Texture.class));
-            return HealthUpImage;
-        }
-
-        if (powerUpEntity == PowerupType.SPEED_BOOST) {
-            SpeedUpImage = new Image(ServiceLocator.getResourceService().getAsset("images/Potion4re.png", Texture.class));
-            return SpeedUpImage;
-        }
-
-        if (powerUpEntity == PowerupType.EXTRA_LIFE) {
-            ExtraLifeImage = new Image(ServiceLocator.getResourceService().getAsset("images/powerups/extra_life.png", Texture.class));
-            return ExtraLifeImage;
-        }
-        else return null;
+        PowerupConfig config = configs.GetPowerupConfig(powerUpEntity);
+        return config != null ? new Image(ServiceLocator.getResourceService().getAsset(config.imagePath, Texture.class)) : null;
     }
 
     /**

--- a/source/core/src/main/com/csse3200/game/components/obstacleMinigame/ObstacleMiniGameActions.java
+++ b/source/core/src/main/com/csse3200/game/components/obstacleMinigame/ObstacleMiniGameActions.java
@@ -3,11 +3,8 @@ package com.csse3200.game.components.obstacleMinigame;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.csse3200.game.GdxGame;
 import com.csse3200.game.components.maingame.MainGameActions;
-import com.csse3200.game.ui.SpaceMiniTransition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.csse3200.game.ui.UIComponent.skin;
 
 public class ObstacleMiniGameActions extends MainGameActions {
     private static final Logger logger = LoggerFactory.getLogger(ObstacleMiniGameActions.class);
@@ -25,15 +22,4 @@ public class ObstacleMiniGameActions extends MainGameActions {
     public void create() {
         entity.getEvents().addListener("returnPlanet", this::onReturnPlanet);
     }
-
-    /**
-     * Called when exit screen is triggered, display a dialog before switching the screen
-     */
-    protected void onReturnPlanet() {
-        logger.info("Exiting main game screen");
-        SpaceMiniTransition mainAlertBox = new SpaceMiniTransition(game, "Return to planet", skin, "Game Over");
-        mainAlertBox.showDialog(stage, super::onReturnPlanet);
-    }
-
-
 }

--- a/source/core/src/main/com/csse3200/game/entities/Entity.java
+++ b/source/core/src/main/com/csse3200/game/entities/Entity.java
@@ -308,8 +308,8 @@ public class Entity {
     if (!enabled) {
       return;
     }
-    for (Component component : createdComponents) {
-      component.triggerEarlyUpdate();
+    for (int i = 0; i < createdComponents.size; i++) {
+      createdComponents.get(i).triggerEarlyUpdate();
     }
   }
 
@@ -321,8 +321,8 @@ public class Entity {
     if (!enabled) {
       return;
     }
-    for (Component component : createdComponents) {
-      component.triggerUpdate();
+    for (int i = 0; i < createdComponents.size; i++) {
+      createdComponents.get(i).triggerUpdate();
     }
   }
 

--- a/source/core/src/main/com/csse3200/game/entities/EntityService.java
+++ b/source/core/src/main/com/csse3200/game/entities/EntityService.java
@@ -95,9 +95,9 @@ public class EntityService {
    * Update all registered entities. Should only be called from the main game loop.
    */
   public void update() {
-    for (Entity entity : entities) {
-      entity.earlyUpdate();
-      entity.update();
+    for (int i = 0; i < entities.size; i++) {
+      entities.get(i).earlyUpdate();
+      entities.get(i).update();
     }
   }
 


### PR DESCRIPTION
This pull request fixes two issues with regard to game crashes and file path errors.

- Fixed Entity and EntityService base code to not use iterators.
- Fixed PowerUpDisplayHUD to use config files to load images.
- Removed Animation from Space Mini-game return button.