### PR TITLE
Fixed a gamebreaking bug caused by the NPC jail.

### DIFF
--- a/source/core/src/main/com/csse3200/game/entities/factories/NPCFactory.java
+++ b/source/core/src/main/com/csse3200/game/entities/factories/NPCFactory.java
@@ -295,14 +295,18 @@ public class NPCFactory {
                     .addComponent(new InteractionControllerComponent(true))
                     .addComponent(new DialogComponent(dialogueBox))
                     .addComponent(new PhysicsMovementComponent());
-    Jail.addComponent(new InteractableComponent(entity -> {Jail.dispose();
+    Jail.addComponent(new InteractableComponent(entity -> {
+      // To previously make the jail dissapear, we were disposing of it, now we simply make it dissapear by scaling it
+      // to zero. See https://github.com/UQcsse3200/2023-studio-2/issues/473
+      Jail.setScale(0.0f, 0.0f);
+
       String[] storytext= {"NPC: (Desperate) Hey, you there!\n Please, help me! I've been stuck in\nhere for days!"
               ,"NPC: (Relieved) Thank you so much!\nThere's a spaceship not far from here\nthat can get us off this planet. But\nbe warned, it's guarded by infected."
               ,"Emily: We can handle it. \nLead the way!"};
       String[] titletext= {"","",""};
-      Jail.getComponent(DialogComponent.class).showdialogue(storytext, titletext);},1f));
+      Jail.getComponent(DialogComponent.class).showdialogue(storytext, titletext);}
+            ,1f));
     Jail.scaleHeight(1.7f);
-    animator.startAnimation("jail_close");
     return Jail;
   }
   public static Entity createFire() {


### PR DESCRIPTION
## Bug
#473 - Disposing the main game area causes the game to crash.

## Cause
After hours of debugging, it was found that this bug was caused by the NPC jail disposing of itself while still being referenced by the main game area. This meant that when the main game area attempted to dispose of itself upon changing screens it would try to dispose of the already disposed entity, causing the game to crash.

## Fix
By scaling the entity down to a size of 0 pixels, it can be made invisible without disposing of it.