### PR TITLE
Bug Fixes: Screen change game crash + Player reference update 

### DIFF
--- a/source/core/src/main/com/csse3200/game/screens/PlanetScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/PlanetScreen.java
@@ -156,7 +156,6 @@ public class PlanetScreen extends ScreenAdapter {
             this.currentAreaName = name;
             this.allGameAreas.get(currentAreaName).create();
             this.player = allGameAreas.get(currentAreaName).getPlayer();
-
             ServiceLocator.getGameStateObserverService().trigger("updatePlanet", "gameArea", this.currentAreaName);
             return true;
         }

--- a/source/core/src/main/com/csse3200/game/screens/PlanetScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/PlanetScreen.java
@@ -5,7 +5,6 @@ import com.badlogic.gdx.ScreenAdapter;
 import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.scenes.scene2d.Stage;
 import com.csse3200.game.GdxGame;
-import com.csse3200.game.areas.GameArea;
 import com.csse3200.game.areas.MapGameArea;
 import com.csse3200.game.areas.mapConfig.*;
 import com.csse3200.game.areas.terrain.TerrainFactory;
@@ -292,11 +291,7 @@ public class PlanetScreen extends ScreenAdapter {
      */
     public void clear() {
         logger.debug(String.format("Disposing %s screen", this.name));
-
-        for (GameArea area : allGameAreas.values()) {
-            area.dispose();
-        }
-
+        this.allGameAreas.get(currentAreaName).dispose();
         renderer.dispose();
         unloadAssets();
         ServiceLocator.getGameStateObserverService().trigger("remove", "gameArea");

--- a/source/core/src/main/com/csse3200/game/screens/PlanetScreen.java
+++ b/source/core/src/main/com/csse3200/game/screens/PlanetScreen.java
@@ -156,6 +156,8 @@ public class PlanetScreen extends ScreenAdapter {
             this.allGameAreas.get(currentAreaName).dispose();
             this.currentAreaName = name;
             this.allGameAreas.get(currentAreaName).create();
+            this.player = allGameAreas.get(currentAreaName).getPlayer();
+
             ServiceLocator.getGameStateObserverService().trigger("updatePlanet", "gameArea", this.currentAreaName);
             return true;
         }


### PR DESCRIPTION
This bug fix fixes the game crash when screen transitions occur, and appropriately updates the player for the camera moment on game area switch